### PR TITLE
Add POJOs and refactor tests

### DIFF
--- a/src/main/java/pojo/CreateHousehold.java
+++ b/src/main/java/pojo/CreateHousehold.java
@@ -1,0 +1,14 @@
+package pojo;
+
+public class CreateHousehold {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public CreateHousehold setName(String name) {
+        this.name = name;
+        return this;
+    }
+}

--- a/src/main/java/pojo/CreateUser.java
+++ b/src/main/java/pojo/CreateUser.java
@@ -1,0 +1,34 @@
+package pojo;
+
+public class CreateUser {
+    private String firstName;
+    private String lastName;
+    private String email;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public CreateUser setFirstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public CreateUser setLastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public CreateUser setEmail(String email) {
+        this.email = email;
+        return this;
+    }
+}

--- a/src/main/java/pojo/CreateWishlist.java
+++ b/src/main/java/pojo/CreateWishlist.java
@@ -1,0 +1,34 @@
+package pojo;
+
+public class CreateWishlist {
+    private String firstName;
+    private String lastName;
+    private String email;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public CreateWishlist setFirstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public CreateWishlist setLastName(String lastName) {
+        this.lastName = lastName;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public CreateWishlist setEmail(String email) {
+        this.email = email;
+        return this;
+    }
+}

--- a/src/main/java/util/Enpoint.java
+++ b/src/main/java/util/Enpoint.java
@@ -7,6 +7,8 @@ public class Enpoint {
         public static  String CARTS  = "/carts/";
         public static  String USERS  = "/users/";
         public static  String USERS_ID_1 = "/users/1";
+        public static  String HOUSEHOLDS = "/households/";
+        public static  String WISHLISTS = "/wishlists/";
         public static  String BOOKS  = "/books/";
         public static  String BOOKS_ID_6  = "/books/6";
         public static  String IN_VALID_BOOKS_ID  = "/books/0";

--- a/src/test/java/paths/Paths.java
+++ b/src/test/java/paths/Paths.java
@@ -3,5 +3,11 @@ package paths;
 public class Paths {
     public static final String BOOK_SCHEMA_PATH =
             System.getProperty("user.dir") + "/src/test/resources/schema/book-schema.json";
+    public static final String HOUSEHOLD_SCHEMA_PATH =
+            System.getProperty("user.dir") + "/src/test/resources/schema/household-schema.json";
+    public static final String USER_SCHEMA_PATH =
+            System.getProperty("user.dir") + "/src/test/resources/schema/user-schema.json";
+    public static final String WISHLIST_SCHEMA_PATH =
+            System.getProperty("user.dir") + "/src/test/resources/schema/wishlist-schema.json";
 }
 

--- a/src/test/java/testcases/books/TC01_CreateNewBook.java
+++ b/src/test/java/testcases/books/TC01_CreateNewBook.java
@@ -75,7 +75,5 @@ public class TC01_CreateNewBook extends TestBase {
 
         Assert.assertNotNull(response.jsonPath().getString("createdAt"), "createdAt should not be null");
         Assert.assertNotNull(response.jsonPath().getString("updatedAt"), "updatedAt should not be null");
-
-        System.out.println("✅ Book created successfully. ID: " + bookID);
     }
 }

--- a/src/test/java/testcases/books/TC02_Get_A_Book.java
+++ b/src/test/java/testcases/books/TC02_Get_A_Book.java
@@ -4,29 +4,36 @@ import io.restassured.module.jsv.JsonSchemaValidator;
 import io.restassured.response.Response;
 import org.testng.annotations.Test;
 import testcases.TestBase;
+import java.util.Map;
 
 import java.io.File;
 
+import static builder.RequestBuilder.createRequestSpecification;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 import static paths.Paths.BOOK_SCHEMA_PATH;
+import static util.Enpoint.BOOKS;
 
 public class TC02_Get_A_Book extends TestBase {
 
     @Test(priority = 1, description = "Check Get Books working and return response as excpected")
     public void checkGetBooksWorking_P(){
-        Response response = given().log().all()
-                .header("Content-Type", "application/json")
-                .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
-                .then().log().all()
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+
+        Response response = given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .when().get(BOOKS + bookID)
+                .then()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
                 .body(JsonSchemaValidator.matchesJsonSchema(new File(BOOK_SCHEMA_PATH)))
                 .extract().response();
-        System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
-        System.out.println("✅ [TC01] Response matches the expected JSON schema");
+
     }
 }

--- a/src/test/java/testcases/books/TC04_Get_Existed_Book.java
+++ b/src/test/java/testcases/books/TC04_Get_Existed_Book.java
@@ -6,28 +6,34 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import java.io.File;
+import java.util.Map;
 
+import static builder.RequestBuilder.createRequestSpecification;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 import static paths.Paths.BOOK_SCHEMA_PATH;
+import static util.Enpoint.BOOKS;
 
 public class TC04_Get_Existed_Book extends TestBase {
 
     @Test(priority = 1, description = "Check Get Books working and return response as excpected")
     public void checkGetBooksWorking_P(){
-        Response response = given().log().all()
-                .header("Content-Type", "application/json")
-                .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
-                .then().log().all()
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+
+        Response response = given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .when().get(BOOKS + bookID) // ✅ Use GET and pass the variable
+                .then()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
                 .body(JsonSchemaValidator.matchesJsonSchema(new File(BOOK_SCHEMA_PATH)))
                 .extract().response();
-        System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
-        System.out.println("✅ [TC01] Response matches the expected JSON schema");
     }
 
 

--- a/src/test/java/testcases/books/TC05_Partial_Update_A_Book.java
+++ b/src/test/java/testcases/books/TC05_Partial_Update_A_Book.java
@@ -1,15 +1,21 @@
 package testcases.books;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.response.Response;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import testcases.TestBase;
+import pojo.CreateBook;
+import java.io.File;
+import java.util.Map;
 
+import static builder.RequestBuilder.createRequestSpecification;
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
-import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
+import static paths.Paths.BOOK_SCHEMA_PATH;
+import static util.Enpoint.BOOKS;
 import static util.Utililty.*;
 
 public class TC05_Partial_Update_A_Book extends TestBase {
@@ -20,68 +26,67 @@ public class TC05_Partial_Update_A_Book extends TestBase {
     String author = generateRandomAuthor();
 
     @Test(dependsOnMethods = {"testcases.books.TC03_Update_Existing_Book.updateExistingBook_P"})
-    public void partialUpdateExistingBook_P() {
-        Response response = given().log().all()
-                .header("Content-Type", "application/json")
-                .header("g-token", "ROM831ESV")
-                .auth().preemptive().basic("admin","admin")
-                .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().patch("/books/" + bookID)
-                .then().log().all()
-                .assertThat().statusCode(200).assertThat()
+    public void partialUpdateExistingBook_P() throws JsonProcessingException {
+        CreateBook book = new CreateBook()
+                .setTitle(title)
+                .setAuthor(author)
+                .setIsbn(isbn)
+                .setReleaseDate(releaseDate);
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        Response response = given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .auth().preemptive().basic("admin", "admin")
+                .body(mapper.writeValueAsString(book))
+                .when().patch(BOOKS + bookID)
+                .then()
+                .statusCode(200)
                 .time(lessThan(2000L))
                 .body("id", notNullValue())
-                .body(matchesJsonSchemaInClasspath("schema/book-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(BOOK_SCHEMA_PATH)))
                 .extract().response();
-        System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
-        System.out.println("✅ [TC01] Response matches the expected JSON schema");
 
         long responseTime = response.getTime();
-        System.out.println("✅ [TC02] Validate Response time is less than 5000ms");
         Assert.assertTrue(responseTime < 5000, "Response time should be < 5000ms, but was: " + responseTime);
 
         TestBase.bookID = response.jsonPath().getInt("id");
         Assert.assertNotNull(bookID, "Book ID should not be null");
-        System.out.println("✅ [TC03] Validate response body contains a non-null 'id'");
 
         Assert.assertTrue(bookID > 0, "Book ID should be a positive number");
-        System.out.println("✅ [TC04] Validate 'id' is a number and positive");
 
         String actualTitle = response.jsonPath().getString("title");
         Assert.assertNotNull(actualTitle, "Title should not be null");
         Assert.assertFalse(actualTitle.isEmpty(), "Title should not be empty");
         Assert.assertEquals(actualTitle, title, "Title should match the request");
-        System.out.println("✅ [TC09] Validate 'title' is not null, not empty, and matches the input");
 
         String actualAuthor = response.jsonPath().getString("author");
         Assert.assertNotNull(actualAuthor, "Author should not be null");
         Assert.assertFalse(actualAuthor.isEmpty(), "Author should not be empty");
         Assert.assertEquals(actualAuthor, author, "Author should match the request");
-        System.out.println("✅ [TC10] Validate 'author' is not null, not empty, and matches the input");
 
         String actualIsbn = response.jsonPath().getString("isbn");
         Assert.assertNotNull(actualIsbn, "ISBN should not be null");
         Assert.assertFalse(actualIsbn.isEmpty(), "ISBN should not be empty");
         Assert.assertEquals(actualIsbn, isbn, "ISBN should match the request");
-        System.out.println("✅ [TC11] Validate 'isbn' is not null, not empty, and matches the input");
 
         String actualReleaseDate = response.jsonPath().getString("releaseDate");
         Assert.assertNotNull(actualReleaseDate, "ReleaseDate should not be null");
         Assert.assertFalse(actualReleaseDate.isEmpty(), "ReleaseDate should not be empty");
         Assert.assertEquals(actualReleaseDate, releaseDate, "ReleaseDate should match the request");
-        System.out.println("✅ [TC12] Validate 'releaseDate' is not null, not empty, and matches the input");
 
         String createdAt = response.jsonPath().getString("createdAt");
         Assert.assertNotNull(createdAt, "createdAt should not be null or empty");
         Assert.assertFalse(createdAt.isEmpty(), "createdAt should not be empty");
-        System.out.println("✅ [TC13] Validate 'createdAt' is not null or empty");
 
         String updatedAt = response.jsonPath().getString("updatedAt");
         Assert.assertNotNull(updatedAt, "updatedAt should not be null or empty");
         Assert.assertFalse(updatedAt.isEmpty(), "updatedAt should not be empty");
-        System.out.println("✅ [TC14] Validate 'updatedAt' is not null or empty");
-
-        System.out.println("✅ All assertions passed. Book ID: " + bookID);
     }
 
 }

--- a/src/test/java/testcases/books/TC06_Get_Existed_Book.java
+++ b/src/test/java/testcases/books/TC06_Get_Existed_Book.java
@@ -6,28 +6,34 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import java.io.File;
+import java.util.Map;
 
+import static builder.RequestBuilder.createRequestSpecification;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 import static paths.Paths.BOOK_SCHEMA_PATH;
+import static util.Enpoint.BOOKS;
 
 public class TC06_Get_Existed_Book extends TestBase {
 
     @Test(priority = 1, description = "Check Get Books working and return response as excpected")
     public void checkGetBooksWorking_P(){
-        Response response = given().log().all()
-                .header("Content-Type", "application/json")
-                .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
-                .then().log().all()
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+
+        Response response = given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .when().get(BOOKS + bookID) // ✅ Use GET and pass the variable
+                .then()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
                 .body(JsonSchemaValidator.matchesJsonSchema(new File(BOOK_SCHEMA_PATH)))
                 .extract().response();
-        System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
-        System.out.println("✅ [TC01] Response matches the expected JSON schema");
     }
 
 

--- a/src/test/java/testcases/books/TC08_Get_A_Book.java
+++ b/src/test/java/testcases/books/TC08_Get_A_Book.java
@@ -4,18 +4,26 @@ import io.restassured.response.Response;
 import org.testng.annotations.Test;
 import testcases.TestBase;
 
+import java.util.Map;
+import static builder.RequestBuilder.createRequestSpecification;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.lessThan;
+import static util.Enpoint.BOOKS;
 
 public class TC08_Get_A_Book extends TestBase {
 
     @Test(priority = 1, description = "Check that GET after DELETE returns 404 Not Found for deleted book")
     public void checkGetBooksWorking_P(){
-        Response response = given().log().all()
-                .header("Content-Type", "application/json")
-                .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
-                .then().log().all()
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+
+        Response response = given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .when().get(BOOKS + bookID) // ✅ Use GET and pass the variable
+                .then()
                 .assertThat().statusCode(404).assertThat()
                 .time(lessThan(2000L))
                 .extract().response();
@@ -27,10 +35,7 @@ public class TC08_Get_A_Book extends TestBase {
         // ✅ Optional: schema validation if your 404 error has a defined schema
         // .body(matchesJsonSchemaInClasspath("error-schema.json"));
 
-        // 📘 Logging
-        System.out.println("✅ [TC08] Status code is 404 - book was successfully deleted");
-        System.out.println("✅ [TC08] Response time is under 2 seconds");
-        System.out.println("✅ [TC08] Book with ID " + bookID + " no longer exists in the system");
+        // Optional logging if needed
     }
 
 }

--- a/src/test/java/testcases/houseHolding/TC01_Create_New_Household.java
+++ b/src/test/java/testcases/houseHolding/TC01_Create_New_Household.java
@@ -1,16 +1,22 @@
 package testcases.houseHolding;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.module.jsv.JsonSchemaValidator;
 import io.restassured.response.Response;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import testcases.TestBase;
+import pojo.CreateHousehold;
+import java.io.File;
+import java.util.Map;
 
 import java.io.File;
 
+import static builder.RequestBuilder.createRequestSpecification;
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
-import static model.CreateBookBody.getCreateHouseholdBody;
+import static paths.Paths.HOUSEHOLD_SCHEMA_PATH;
+import static util.Enpoint.HOUSEHOLDS;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
 import static util.Utililty.*;
@@ -20,52 +26,47 @@ public class TC01_Create_New_Household extends TestBase {
     String fullName = generateRandomFullName();
 
     @Test(priority = 1, description = "Create new book with valid data")
-    public void createNewBook_P() {
-        Response response = given().log().all()
-                .header("Content-Type", "application/json")
-                .header("g-token", "ROM831ESV")
-                .body(getCreateHouseholdBody(fullName))
-                .when().post("/households")
-                .then().log().all()
-                .assertThat().statusCode(201).assertThat()
+    public void createNewBook_P() throws JsonProcessingException {
+        CreateHousehold household = new CreateHousehold().setName(fullName);
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        Response response = given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(household))
+                .when().post(HOUSEHOLDS)
+                .then()
+                .statusCode(201)
                 .time(lessThan(2000L))
                 .body("id", notNullValue())
-                .body(matchesJsonSchemaInClasspath("schema/household-schema.json"))
-//                .body(JsonSchemaValidator.matchesJsonSchema(new File(System.getProperty("user.dir")+
-//                        "D:\\Course\\APIs Course\\RestAssured_Library\\RestAssured_Library\\src\\" +
-//                        "test\\resources\\schema\\household-schema.json")))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(HOUSEHOLD_SCHEMA_PATH)))
                 .extract().response();
-        System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
-        System.out.println("✅ [TC01] Response matches the expected JSON schema");
 
         long responseTime = response.getTime();
-        System.out.println("✅ [TC02] Validate Response time is less than 5000ms");
         Assert.assertTrue(responseTime < 5000, "Response time should be < 5000ms, but was: " + responseTime);
 
         TestBase.bookID = response.jsonPath().getInt("id");
         Assert.assertNotNull(bookID, "Book ID should not be null");
-        System.out.println("✅ [TC03] Validate response body contains a non-null 'id'");
 
         Assert.assertTrue(bookID > 0, "Book ID should be a positive number");
-        System.out.println("✅ [TC04] Validate 'id' is a number and positive");
 
         String actualName = response.jsonPath().getString("name");
         Assert.assertNotNull(actualName, "Title should not be null");
         Assert.assertFalse(actualName.isEmpty(), "Title should not be empty");
         Assert.assertEquals(actualName, fullName, "Title should match the request");
-        System.out.println("✅ [TC09] Validate 'title' is not null, not empty, and matches the input");
 
         String createdAt = response.jsonPath().getString("createdAt");
         Assert.assertNotNull(createdAt, "createdAt should not be null or empty");
         Assert.assertFalse(createdAt.isEmpty(), "createdAt should not be empty");
-        System.out.println("✅ [TC13] Validate 'createdAt' is not null or empty");
 
         String updatedAt = response.jsonPath().getString("updatedAt");
         Assert.assertNotNull(updatedAt, "updatedAt should not be null or empty");
         Assert.assertFalse(updatedAt.isEmpty(), "updatedAt should not be empty");
-        System.out.println("✅ [TC14] Validate 'updatedAt' is not null or empty");
-
-        System.out.println("✅ All assertions passed. Book ID: " + bookID);
     }
 
 }


### PR DESCRIPTION
## Summary
- add CreateHousehold, CreateUser and CreateWishlist POJOs
- extend endpoint constants
- add schema path constants
- refactor some book tests to use RequestBuilder and POJOs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686575be75e8832fbbe04f74f0c5956e