### PR TITLE
Add negative create tests for all domains

### DIFF
--- a/src/test/java/testcases/books/TC09_CreateNewBook_NegativeData.java
+++ b/src/test/java/testcases/books/TC09_CreateNewBook_NegativeData.java
@@ -1,0 +1,139 @@
+package testcases.books;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+import testcases.TestBase;
+import pojo.CreateBook;
+
+import java.util.Map;
+
+import static builder.RequestBuilder.createRequestSpecification;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.lessThan;
+import static util.Enpoint.BOOKS;
+
+public class TC09_CreateNewBook_NegativeData extends TestBase {
+
+    /**
+     * Create book with valid title and author but invalid ISBN (non numeric).
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 1, description = "Create book with invalid ISBN")
+    public void createBook_InvalidIsbn_N() throws JsonProcessingException {
+        CreateBook book = new CreateBook()
+                .setTitle("Invalid ISBN Book")
+                .setAuthor("Author")
+                .setIsbn("invalid_isbn")
+                .setReleaseDate("2000-01-01");
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(book))
+                .when()
+                .post(BOOKS)
+                .then()
+                .statusCode(400)
+                .body(containsString("isbn"))
+                .time(lessThan(5000L));
+    }
+
+    /**
+     * Create book with missing title.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 2, description = "Create book with missing title")
+    public void createBook_MissingTitle_N() throws JsonProcessingException {
+        CreateBook book = new CreateBook()
+                .setTitle("")
+                .setAuthor("Author")
+                .setIsbn("1234567890123")
+                .setReleaseDate("2000-01-01");
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(book))
+                .when()
+                .post(BOOKS)
+                .then()
+                .statusCode(400)
+                .body(containsString("title"))
+                .time(lessThan(5000L));
+    }
+
+    /**
+     * Create book with future release date.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 3, description = "Create book with future release date")
+    public void createBook_FutureReleaseDate_N() throws JsonProcessingException {
+        CreateBook book = new CreateBook()
+                .setTitle("Future Date Book")
+                .setAuthor("Author")
+                .setIsbn("1234567890123")
+                .setReleaseDate("2999-12-31");
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(book))
+                .when()
+                .post(BOOKS)
+                .then()
+                .statusCode(400)
+                .body(containsString("releaseDate"))
+                .time(lessThan(5000L));
+    }
+
+    /**
+     * Create book with extremely long title.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 4, description = "Create book with very long title")
+    public void createBook_TitleTooLong_N() throws JsonProcessingException {
+        String longTitle = "A".repeat(500);
+        CreateBook book = new CreateBook()
+                .setTitle(longTitle)
+                .setAuthor("Author")
+                .setIsbn("1234567890123")
+                .setReleaseDate("2000-01-01");
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(book))
+                .when()
+                .post(BOOKS)
+                .then()
+                .statusCode(400)
+                .body(containsString("title"))
+                .time(lessThan(5000L));
+    }
+}

--- a/src/test/java/testcases/houseHolding/TC09_CreateNewHousehold_NegativeData.java
+++ b/src/test/java/testcases/houseHolding/TC09_CreateNewHousehold_NegativeData.java
@@ -1,0 +1,97 @@
+package testcases.houseHolding;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+import testcases.TestBase;
+import pojo.CreateHousehold;
+
+import java.util.Map;
+
+import static builder.RequestBuilder.createRequestSpecification;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.lessThan;
+import static util.Enpoint.HOUSEHOLDS;
+
+public class TC09_CreateNewHousehold_NegativeData extends TestBase {
+
+    /**
+     * Create household with empty name.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 1, description = "Create household with empty name")
+    public void createHousehold_EmptyName_N() throws JsonProcessingException {
+        CreateHousehold household = new CreateHousehold().setName("");
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(household))
+                .when()
+                .post(HOUSEHOLDS)
+                .then()
+                .statusCode(400)
+                .body(containsString("name"))
+                .time(lessThan(5000L));
+    }
+
+    /**
+     * Create household with name too long.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 2, description = "Create household with long name")
+    public void createHousehold_NameTooLong_N() throws JsonProcessingException {
+        String longName = "A".repeat(300);
+        CreateHousehold household = new CreateHousehold().setName(longName);
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(household))
+                .when()
+                .post(HOUSEHOLDS)
+                .then()
+                .statusCode(400)
+                .body(containsString("name"))
+                .time(lessThan(5000L));
+    }
+
+    /**
+     * Create household with null name.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 3, description = "Create household with null name")
+    public void createHousehold_NullName_N() throws JsonProcessingException {
+        CreateHousehold household = new CreateHousehold().setName(null);
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(household))
+                .when()
+                .post(HOUSEHOLDS)
+                .then()
+                .statusCode(400)
+                .body(containsString("name"))
+                .time(lessThan(5000L));
+    }
+}

--- a/src/test/java/testcases/users/TC09_CreateNewUser_NegativeData.java
+++ b/src/test/java/testcases/users/TC09_CreateNewUser_NegativeData.java
@@ -1,0 +1,105 @@
+package testcases.users;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+import testcases.TestBase;
+import pojo.CreateUser;
+
+import java.util.Map;
+
+import static builder.RequestBuilder.createRequestSpecification;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.lessThan;
+import static util.Enpoint.USERS;
+
+public class TC09_CreateNewUser_NegativeData extends TestBase {
+
+    /**
+     * Create user with invalid email format.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 1, description = "Create user with invalid email")
+    public void createUser_InvalidEmail_N() throws JsonProcessingException {
+        CreateUser user = new CreateUser()
+                .setFirstName("John")
+                .setLastName("Doe")
+                .setEmail("invalid_email");
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(user))
+                .when()
+                .post(USERS)
+                .then()
+                .statusCode(400)
+                .body(containsString("email"))
+                .time(lessThan(5000L));
+    }
+
+    /**
+     * Create user with null first name.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 2, description = "Create user with null first name")
+    public void createUser_NullFirstName_N() throws JsonProcessingException {
+        CreateUser user = new CreateUser()
+                .setFirstName(null)
+                .setLastName("Doe")
+                .setEmail("john@example.com");
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(user))
+                .when()
+                .post(USERS)
+                .then()
+                .statusCode(400)
+                .body(containsString("firstName"))
+                .time(lessThan(5000L));
+    }
+
+    /**
+     * Create user with missing last name.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 3, description = "Create user with empty last name")
+    public void createUser_EmptyLastName_N() throws JsonProcessingException {
+        CreateUser user = new CreateUser()
+                .setFirstName("John")
+                .setLastName("")
+                .setEmail("john@example.com");
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(user))
+                .when()
+                .post(USERS)
+                .then()
+                .statusCode(400)
+                .body(containsString("lastName"))
+                .time(lessThan(5000L));
+    }
+}

--- a/src/test/java/testcases/wishList/TC09_CreateNewWishlist_NegativeData.java
+++ b/src/test/java/testcases/wishList/TC09_CreateNewWishlist_NegativeData.java
@@ -1,0 +1,105 @@
+package testcases.wishList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+import testcases.TestBase;
+import pojo.CreateWishlist;
+
+import java.util.Map;
+
+import static builder.RequestBuilder.createRequestSpecification;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.lessThan;
+import static util.Enpoint.WISHLISTS;
+
+public class TC09_CreateNewWishlist_NegativeData extends TestBase {
+
+    /**
+     * Create wishlist with invalid email.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 1, description = "Create wishlist with invalid email")
+    public void createWishlist_InvalidEmail_N() throws JsonProcessingException {
+        CreateWishlist wishlist = new CreateWishlist()
+                .setFirstName("John")
+                .setLastName("Doe")
+                .setEmail("invalid_email");
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(wishlist))
+                .when()
+                .post(WISHLISTS)
+                .then()
+                .statusCode(400)
+                .body(containsString("email"))
+                .time(lessThan(5000L));
+    }
+
+    /**
+     * Create wishlist with empty first name.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 2, description = "Create wishlist with empty first name")
+    public void createWishlist_EmptyFirstName_N() throws JsonProcessingException {
+        CreateWishlist wishlist = new CreateWishlist()
+                .setFirstName("")
+                .setLastName("Doe")
+                .setEmail("john@example.com");
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(wishlist))
+                .when()
+                .post(WISHLISTS)
+                .then()
+                .statusCode(400)
+                .body(containsString("firstName"))
+                .time(lessThan(5000L));
+    }
+
+    /**
+     * Create wishlist with null last name.
+     * Expect 400 Bad Request.
+     */
+    @Test(priority = 3, description = "Create wishlist with null last name")
+    public void createWishlist_NullLastName_N() throws JsonProcessingException {
+        CreateWishlist wishlist = new CreateWishlist()
+                .setFirstName("John")
+                .setLastName(null)
+                .setEmail("john@example.com");
+
+        Map<String, String> headers = Map.of(
+                "Content-Type", "application/json",
+                "g-token", "ROM831ESV"
+        );
+        Map<String, String> queryParameters = Map.of();
+        ObjectMapper mapper = new ObjectMapper();
+
+        given()
+                .spec(createRequestSpecification(headers, queryParameters))
+                .body(mapper.writeValueAsString(wishlist))
+                .when()
+                .post(WISHLISTS)
+                .then()
+                .statusCode(400)
+                .body(containsString("lastName"))
+                .time(lessThan(5000L));
+    }
+}


### PR DESCRIPTION
## Summary
- add negative create tests for books
- add negative create tests for households
- add negative create tests for users
- add negative create tests for wishlists

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659b3db38c832f84854bc4ae3d46a7