### PR TITLE
Fix update tests dependsOn method reference

### DIFF
--- a/src/test/java/testcases/books/TC03_Update_Existing_Book.java
+++ b/src/test/java/testcases/books/TC03_Update_Existing_Book.java
@@ -25,7 +25,7 @@ public class TC03_Update_Existing_Book extends TestBase {
     String title = generateRandomTitle();
     String author = generateRandomAuthor();
 
-    @Test(dependsOnMethods = {"testcases.books.TC01_CreateNewBook.createNewBook_P"})
+    @Test(dependsOnMethods = {"testcases.books.TC01_CreateNewBook.TC01_createNewBook_ShouldReturnValidResponse_P"})
 
     public void updateExistingBook_P() throws JsonProcessingException {
         CreateBook book = new CreateBook()

--- a/src/test/java/testcases/houseHolding/TC03_Update_Existing_Household.java
+++ b/src/test/java/testcases/houseHolding/TC03_Update_Existing_Household.java
@@ -19,7 +19,7 @@ public class TC03_Update_Existing_Household extends TestBase {
     String title = generateRandomTitle();
     String author = generateRandomAuthor();
 
-    @Test(priority = 1, dependsOnMethods = {"testcases.Books.TC01_CreateNewBook.createNewBook_P"}, description = "update existed book with valid data")
+    @Test(priority = 1, dependsOnMethods = {"testcases.books.TC01_CreateNewBook.TC01_createNewBook_ShouldReturnValidResponse_P"}, description = "update existed book with valid data")
 
     public void updateExistingBook_P() {
         Response response = given().log().all()

--- a/src/test/java/testcases/users/TC03_Update_Existing_User.java
+++ b/src/test/java/testcases/users/TC03_Update_Existing_User.java
@@ -19,7 +19,7 @@ public class TC03_Update_Existing_User extends TestBase {
     String title = generateRandomTitle();
     String author = generateRandomAuthor();
 
-    @Test(priority = 1, dependsOnMethods = {"testcases.Books.TC01_CreateNewBook.createNewBook_P"}, description = "update existed book with valid data")
+    @Test(priority = 1, dependsOnMethods = {"testcases.books.TC01_CreateNewBook.TC01_createNewBook_ShouldReturnValidResponse_P"}, description = "update existed book with valid data")
 
     public void updateExistingBook_P() {
         Response response = given().log().all()

--- a/src/test/java/testcases/wishList/TC03_Update_Existing_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC03_Update_Existing_Wishlist.java
@@ -19,7 +19,7 @@ public class TC03_Update_Existing_Wishlist extends TestBase {
     String title = generateRandomTitle();
     String author = generateRandomAuthor();
 
-    @Test(priority = 1, dependsOnMethods = {"testcases.Books.TC01_CreateNewBook.createNewBook_P"}, description = "update existed book with valid data")
+    @Test(priority = 1, dependsOnMethods = {"testcases.books.TC01_CreateNewBook.TC01_createNewBook_ShouldReturnValidResponse_P"}, description = "update existed book with valid data")
 
     public void updateExistingBook_P() {
         Response response = given().log().all()


### PR DESCRIPTION
## Summary
- fix dependsOnMethods in TC03_Update_Existing_Book
- match dependency names in household/user/wishlist update tests

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ebf8774c832f98c65eac389bd725