### PR TITLE
Fix endpoints and schemas in user suites

### DIFF
--- a/src/test/java/testcases/houseHolding/TC02_Get_A_Household.java
+++ b/src/test/java/testcases/houseHolding/TC02_Get_A_Household.java
@@ -5,7 +5,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.HOUSEHOLD_SCHEMA_PATH;
+import static util.Enpoint.HOUSEHOLDS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
@@ -16,12 +19,12 @@ public class TC02_Get_A_Household extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(HOUSEHOLDS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
-                .body(matchesJsonSchemaInClasspath("schema/household-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(HOUSEHOLD_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/houseHolding/TC03_Update_Existing_Household.java
+++ b/src/test/java/testcases/houseHolding/TC03_Update_Existing_Household.java
@@ -6,7 +6,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.HOUSEHOLD_SCHEMA_PATH;
+import static util.Enpoint.HOUSEHOLDS;
 import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
@@ -19,7 +22,7 @@ public class TC03_Update_Existing_Household extends TestBase {
     String title = generateRandomTitle();
     String author = generateRandomAuthor();
 
-    @Test(priority = 1, dependsOnMethods = {"testcases.books.TC01_CreateNewBook.TC01_createNewBook_ShouldReturnValidResponse_P"}, description = "update existed book with valid data")
+    @Test(priority = 1, dependsOnMethods = {"testcases.houseHolding.TC01_Create_New_Household.createNewBook_P"}, description = "update existed book with valid data")
 
     public void updateExistingBook_P() {
         Response response = given().log().all()
@@ -27,12 +30,12 @@ public class TC03_Update_Existing_Household extends TestBase {
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
                 .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().put("/books/" + bookID)
+                .when().put(HOUSEHOLDS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", notNullValue())
-                .body(matchesJsonSchemaInClasspath("schema/household-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(HOUSEHOLD_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/houseHolding/TC04_Get_Existed_Household.java
+++ b/src/test/java/testcases/houseHolding/TC04_Get_Existed_Household.java
@@ -5,7 +5,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.HOUSEHOLD_SCHEMA_PATH;
+import static util.Enpoint.HOUSEHOLDS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
@@ -16,12 +19,12 @@ public class TC04_Get_Existed_Household extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(HOUSEHOLDS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
-                .body(matchesJsonSchemaInClasspath("schema/household-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(HOUSEHOLD_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/houseHolding/TC05_Partial_Update_Existed_Household.java
+++ b/src/test/java/testcases/houseHolding/TC05_Partial_Update_Existed_Household.java
@@ -6,7 +6,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.HOUSEHOLD_SCHEMA_PATH;
+import static util.Enpoint.HOUSEHOLDS;
 import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
@@ -27,12 +30,12 @@ public class TC05_Partial_Update_Existed_Household extends TestBase {
                 .header("g-token", "ROM831ESV")
                 .auth().preemptive().basic("admin","admin")
                 .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().patch("/books/" + bookID)
+                .when().patch(HOUSEHOLDS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", notNullValue())
-                .body(matchesJsonSchemaInClasspath("schema/household-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(HOUSEHOLD_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/houseHolding/TC06_Get_A_Household.java
+++ b/src/test/java/testcases/houseHolding/TC06_Get_A_Household.java
@@ -5,7 +5,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.HOUSEHOLD_SCHEMA_PATH;
+import static util.Enpoint.HOUSEHOLDS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
@@ -16,12 +19,12 @@ public class TC06_Get_A_Household extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(HOUSEHOLDS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
-                .body(matchesJsonSchemaInClasspath("schema/household-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(HOUSEHOLD_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/houseHolding/TC07_Delete_A_Household.java
+++ b/src/test/java/testcases/houseHolding/TC07_Delete_A_Household.java
@@ -9,6 +9,7 @@ import static io.restassured.RestAssured.given;
 import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.Matchers.lessThan;
 import static util.Utililty.*;
+import static util.Enpoint.HOUSEHOLDS;
 
 public class TC07_Delete_A_Household extends TestBase {
 
@@ -25,7 +26,7 @@ public class TC07_Delete_A_Household extends TestBase {
                 .header("g-token", "ROM831ESV")
                 .auth().preemptive().basic("admin","admin")
                 .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().delete("/books/" + bookID)
+                .when().delete(HOUSEHOLDS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(204).assertThat()
                 .time(lessThan(2000L))

--- a/src/test/java/testcases/houseHolding/TC08_Get_A_Household.java
+++ b/src/test/java/testcases/houseHolding/TC08_Get_A_Household.java
@@ -6,6 +6,7 @@ import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.lessThan;
+import static util.Enpoint.HOUSEHOLDS;
 
 public class TC08_Get_A_Household extends TestBase {
 
@@ -14,7 +15,7 @@ public class TC08_Get_A_Household extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(HOUSEHOLDS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(404).assertThat()
                 .time(lessThan(2000L))

--- a/src/test/java/testcases/users/TC01_Create_New_User.java
+++ b/src/test/java/testcases/users/TC01_Create_New_User.java
@@ -6,7 +6,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.USER_SCHEMA_PATH;
+import static util.Enpoint.USERS;
 import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
@@ -26,12 +29,12 @@ public class TC01_Create_New_User extends TestBase {
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
                 .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().post("/books")
+                .when().post(USERS)
                 .then().log().all()
                 .assertThat().statusCode(201).assertThat()
                 .time(lessThan(2000L))
                 .body("id", notNullValue())
-                .body(matchesJsonSchemaInClasspath("schema/book-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(USER_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/users/TC02_Get_A_User.java
+++ b/src/test/java/testcases/users/TC02_Get_A_User.java
@@ -5,7 +5,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.USER_SCHEMA_PATH;
+import static util.Enpoint.USERS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
@@ -16,12 +19,12 @@ public class TC02_Get_A_User extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(USERS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
-                .body(matchesJsonSchemaInClasspath("schema/household-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(USER_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/users/TC03_Update_Existing_User.java
+++ b/src/test/java/testcases/users/TC03_Update_Existing_User.java
@@ -6,7 +6,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.USER_SCHEMA_PATH;
+import static util.Enpoint.USERS;
 import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
@@ -19,7 +22,7 @@ public class TC03_Update_Existing_User extends TestBase {
     String title = generateRandomTitle();
     String author = generateRandomAuthor();
 
-    @Test(priority = 1, dependsOnMethods = {"testcases.books.TC01_CreateNewBook.TC01_createNewBook_ShouldReturnValidResponse_P"}, description = "update existed book with valid data")
+    @Test(priority = 1, dependsOnMethods = {"testcases.users.TC01_Create_New_User.createNewBook_P"}, description = "update existed book with valid data")
 
     public void updateExistingBook_P() {
         Response response = given().log().all()
@@ -27,12 +30,12 @@ public class TC03_Update_Existing_User extends TestBase {
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
                 .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().put("/books/" + bookID)
+                .when().put(USERS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", notNullValue())
-                .body(matchesJsonSchemaInClasspath("schema/household-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(USER_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/users/TC04_Get_Existed_User.java
+++ b/src/test/java/testcases/users/TC04_Get_Existed_User.java
@@ -5,7 +5,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.USER_SCHEMA_PATH;
+import static util.Enpoint.USERS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
@@ -16,12 +19,12 @@ public class TC04_Get_Existed_User extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(USERS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
-                .body(matchesJsonSchemaInClasspath("schema/household-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(USER_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/users/TC05_Partial_Update_Existed_User.java
+++ b/src/test/java/testcases/users/TC05_Partial_Update_Existed_User.java
@@ -6,7 +6,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.USER_SCHEMA_PATH;
+import static util.Enpoint.USERS;
 import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
@@ -27,12 +30,12 @@ public class TC05_Partial_Update_Existed_User extends TestBase {
                 .header("g-token", "ROM831ESV")
                 .auth().preemptive().basic("admin","admin")
                 .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().patch("/books/" + bookID)
+                .when().patch(USERS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", notNullValue())
-                .body(matchesJsonSchemaInClasspath("schema/household-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(USER_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/users/TC06_Get_A_User.java
+++ b/src/test/java/testcases/users/TC06_Get_A_User.java
@@ -5,7 +5,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.USER_SCHEMA_PATH;
+import static util.Enpoint.USERS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
@@ -16,12 +19,12 @@ public class TC06_Get_A_User extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(USERS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
-                .body(matchesJsonSchemaInClasspath("schema/household-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(USER_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/users/TC07_Delete_A_User.java
+++ b/src/test/java/testcases/users/TC07_Delete_A_User.java
@@ -9,6 +9,7 @@ import static io.restassured.RestAssured.given;
 import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.Matchers.lessThan;
 import static util.Utililty.*;
+import static util.Enpoint.USERS;
 
 public class TC07_Delete_A_User extends TestBase {
 
@@ -25,7 +26,7 @@ public class TC07_Delete_A_User extends TestBase {
                 .header("g-token", "ROM831ESV")
                 .auth().preemptive().basic("admin","admin")
                 .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().delete("/books/" + bookID)
+                .when().delete(USERS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(204).assertThat()
                 .time(lessThan(2000L))

--- a/src/test/java/testcases/users/TC08_Get_A_User.java
+++ b/src/test/java/testcases/users/TC08_Get_A_User.java
@@ -6,6 +6,7 @@ import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.lessThan;
+import static util.Enpoint.USERS;
 
 public class TC08_Get_A_User extends TestBase {
 
@@ -14,7 +15,7 @@ public class TC08_Get_A_User extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(USERS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(404).assertThat()
                 .time(lessThan(2000L))

--- a/src/test/java/testcases/wishList/TC01_Create_New_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC01_Create_New_Wishlist.java
@@ -6,7 +6,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.WISHLIST_SCHEMA_PATH;
+import static util.Enpoint.WISHLISTS;
 import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
@@ -26,12 +29,12 @@ public class TC01_Create_New_Wishlist extends TestBase {
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
                 .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().post("/books")
+                .when().post(WISHLISTS)
                 .then().log().all()
                 .assertThat().statusCode(201).assertThat()
                 .time(lessThan(2000L))
                 .body("id", notNullValue())
-                .body(matchesJsonSchemaInClasspath("schema/book-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(WISHLIST_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/wishList/TC02_Get_A_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC02_Get_A_Wishlist.java
@@ -5,7 +5,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.WISHLIST_SCHEMA_PATH;
+import static util.Enpoint.WISHLISTS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
@@ -16,12 +19,12 @@ public class TC02_Get_A_Wishlist extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(WISHLISTS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
-                .body(matchesJsonSchemaInClasspath("schema/book-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(WISHLIST_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/wishList/TC03_Update_Existing_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC03_Update_Existing_Wishlist.java
@@ -6,7 +6,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.WISHLIST_SCHEMA_PATH;
+import static util.Enpoint.WISHLISTS;
 import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
@@ -19,7 +22,7 @@ public class TC03_Update_Existing_Wishlist extends TestBase {
     String title = generateRandomTitle();
     String author = generateRandomAuthor();
 
-    @Test(priority = 1, dependsOnMethods = {"testcases.books.TC01_CreateNewBook.TC01_createNewBook_ShouldReturnValidResponse_P"}, description = "update existed book with valid data")
+    @Test(priority = 1, dependsOnMethods = {"testcases.wishList.TC01_Create_New_Wishlist.createNewBook_P"}, description = "update existed book with valid data")
 
     public void updateExistingBook_P() {
         Response response = given().log().all()
@@ -27,12 +30,12 @@ public class TC03_Update_Existing_Wishlist extends TestBase {
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
                 .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().put("/books/" + bookID)
+                .when().put(WISHLISTS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", notNullValue())
-                .body(matchesJsonSchemaInClasspath("schema/book-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(WISHLIST_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/wishList/TC04_Get_Existed_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC04_Get_Existed_Wishlist.java
@@ -5,7 +5,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.WISHLIST_SCHEMA_PATH;
+import static util.Enpoint.WISHLISTS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
@@ -16,12 +19,12 @@ public class TC04_Get_Existed_Wishlist extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(WISHLISTS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
-                .body(matchesJsonSchemaInClasspath("schema/book-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(WISHLIST_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/wishList/TC05_Partial_Update_Existed_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC05_Partial_Update_Existed_Wishlist.java
@@ -6,7 +6,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.WISHLIST_SCHEMA_PATH;
+import static util.Enpoint.WISHLISTS;
 import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
@@ -27,12 +30,12 @@ public class TC05_Partial_Update_Existed_Wishlist extends TestBase {
                 .header("g-token", "ROM831ESV")
                 .auth().preemptive().basic("admin","admin")
                 .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().patch("/books/" + bookID)
+                .when().patch(WISHLISTS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", notNullValue())
-                .body(matchesJsonSchemaInClasspath("schema/book-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(WISHLIST_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/wishList/TC06_Get_A_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC06_Get_A_Wishlist.java
@@ -5,7 +5,10 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import io.restassured.module.jsv.JsonSchemaValidator;
+import java.io.File;
+import static paths.Paths.WISHLIST_SCHEMA_PATH;
+import static util.Enpoint.WISHLISTS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
@@ -16,12 +19,12 @@ public class TC06_Get_A_Wishlist extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(WISHLISTS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
                 .time(lessThan(2000L))
                 .body("id", equalTo(bookID)) // ✅ Confirm the correct book is returned
-                .body(matchesJsonSchemaInClasspath("schema/book-schema.json"))
+                .body(JsonSchemaValidator.matchesJsonSchema(new File(WISHLIST_SCHEMA_PATH)))
                 .extract().response();
         System.out.println("✅ [TC00] Response statusCode matches the expected statusCode \"201\"");
         System.out.println("✅ [TC01] Response matches the expected JSON schema");

--- a/src/test/java/testcases/wishList/TC07_Delete_A_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC07_Delete_A_Wishlist.java
@@ -9,6 +9,7 @@ import static io.restassured.RestAssured.given;
 import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.Matchers.lessThan;
 import static util.Utililty.*;
+import static util.Enpoint.WISHLISTS;
 
 public class TC07_Delete_A_Wishlist extends TestBase {
 
@@ -25,7 +26,7 @@ public class TC07_Delete_A_Wishlist extends TestBase {
                 .header("g-token", "ROM831ESV")
                 .auth().preemptive().basic("admin","admin")
                 .body(getCreateBookBody(title, author, isbn, releaseDate))
-                .when().delete("/books/" + bookID)
+                .when().delete(WISHLISTS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(204).assertThat()
                 .time(lessThan(2000L))

--- a/src/test/java/testcases/wishList/TC08_Get_A_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC08_Get_A_Wishlist.java
@@ -6,6 +6,7 @@ import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.lessThan;
+import static util.Enpoint.WISHLISTS;
 
 public class TC08_Get_A_Wishlist extends TestBase {
 
@@ -14,7 +15,7 @@ public class TC08_Get_A_Wishlist extends TestBase {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .when().get("/books/" + bookID) // ✅ Use GET and pass the variable
+                .when().get(WISHLISTS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(404).assertThat()
                 .time(lessThan(2000L))


### PR DESCRIPTION
## Summary
- update household, user and wishlist tests to use endpoint constants
- validate each API against its correct schema
- update dependencies in `dependsOnMethods`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d53e8150832fb0f8d44786e0397d