### PR TITLE
Fix wishlist tests to use wishlist payload

### DIFF
--- a/src/test/java/testcases/wishList/TC01_Create_New_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC01_Create_New_Wishlist.java
@@ -10,25 +10,24 @@ import io.restassured.module.jsv.JsonSchemaValidator;
 import java.io.File;
 import static paths.Paths.WISHLIST_SCHEMA_PATH;
 import static util.Enpoint.WISHLISTS;
-import static model.CreateBookBody.getCreateBookBody;
+import static model.CreateBookBody.getCreateWishlistBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
 import static util.Utililty.*;
 
 public class TC01_Create_New_Wishlist extends TestBase {
 
-    String isbn = generateRandomIsbn();
-    String releaseDate = generateRandomPastDate();
-    String title = generateRandomTitle();
-    String author = generateRandomAuthor();
+    String firstName = getRandomFirstName();
+    String lastName = generateRandomLastName();
+    String email = generateRandomEmail("example.com", ".");
 
-    @Test(priority = 1, description = "Create new book with valid data")
+    @Test(priority = 1, description = "Create new wishlist with valid data")
 
-    public void createNewBook_P() {
+    public void createNewWishlist_P() {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .body(getCreateBookBody(title, author, isbn, releaseDate))
+                .body(getCreateWishlistBody(firstName, lastName, email))
                 .when().post(WISHLISTS)
                 .then().log().all()
                 .assertThat().statusCode(201).assertThat()
@@ -50,29 +49,23 @@ public class TC01_Create_New_Wishlist extends TestBase {
         Assert.assertTrue(bookID > 0, "Book ID should be a positive number");
         System.out.println("✅ [TC04] Validate 'id' is a number and positive");
 
-        String actualTitle = response.jsonPath().getString("title");
-        Assert.assertNotNull(actualTitle, "Title should not be null");
-        Assert.assertFalse(actualTitle.isEmpty(), "Title should not be empty");
-        Assert.assertEquals(actualTitle, title, "Title should match the request");
-        System.out.println("✅ [TC09] Validate 'title' is not null, not empty, and matches the input");
+        String actualFirstName = response.jsonPath().getString("firstName");
+        Assert.assertNotNull(actualFirstName, "First name should not be null");
+        Assert.assertFalse(actualFirstName.isEmpty(), "First name should not be empty");
+        Assert.assertEquals(actualFirstName, firstName, "First name should match the request");
+        System.out.println("✅ [TC09] Validate 'firstName' is not null, not empty, and matches the input");
 
-        String actualAuthor = response.jsonPath().getString("author");
-        Assert.assertNotNull(actualAuthor, "Author should not be null");
-        Assert.assertFalse(actualAuthor.isEmpty(), "Author should not be empty");
-        Assert.assertEquals(actualAuthor, author, "Author should match the request");
-        System.out.println("✅ [TC10] Validate 'author' is not null, not empty, and matches the input");
+        String actualLastName = response.jsonPath().getString("lastName");
+        Assert.assertNotNull(actualLastName, "Last name should not be null");
+        Assert.assertFalse(actualLastName.isEmpty(), "Last name should not be empty");
+        Assert.assertEquals(actualLastName, lastName, "Last name should match the request");
+        System.out.println("✅ [TC10] Validate 'lastName' is not null, not empty, and matches the input");
 
-        String actualIsbn = response.jsonPath().getString("isbn");
-        Assert.assertNotNull(actualIsbn, "ISBN should not be null");
-        Assert.assertFalse(actualIsbn.isEmpty(), "ISBN should not be empty");
-        Assert.assertEquals(actualIsbn, isbn, "ISBN should match the request");
-        System.out.println("✅ [TC11] Validate 'isbn' is not null, not empty, and matches the input");
-
-        String actualReleaseDate = response.jsonPath().getString("releaseDate");
-        Assert.assertNotNull(actualReleaseDate, "ReleaseDate should not be null");
-        Assert.assertFalse(actualReleaseDate.isEmpty(), "ReleaseDate should not be empty");
-        Assert.assertEquals(actualReleaseDate, releaseDate, "ReleaseDate should match the request");
-        System.out.println("✅ [TC12] Validate 'releaseDate' is not null, not empty, and matches the input");
+        String actualEmail = response.jsonPath().getString("email");
+        Assert.assertNotNull(actualEmail, "Email should not be null");
+        Assert.assertFalse(actualEmail.isEmpty(), "Email should not be empty");
+        Assert.assertEquals(actualEmail, email, "Email should match the request");
+        System.out.println("✅ [TC11] Validate 'email' is not null, not empty, and matches the input");
 
         String createdAt = response.jsonPath().getString("createdAt");
         Assert.assertNotNull(createdAt, "createdAt should not be null or empty");

--- a/src/test/java/testcases/wishList/TC03_Update_Existing_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC03_Update_Existing_Wishlist.java
@@ -10,26 +10,25 @@ import io.restassured.module.jsv.JsonSchemaValidator;
 import java.io.File;
 import static paths.Paths.WISHLIST_SCHEMA_PATH;
 import static util.Enpoint.WISHLISTS;
-import static model.CreateBookBody.getCreateBookBody;
+import static model.CreateBookBody.getCreateWishlistBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
 import static util.Utililty.*;
 
 public class TC03_Update_Existing_Wishlist extends TestBase {
 
-    String isbn = generateRandomIsbn();
-    String releaseDate = generateRandomPastDate();
-    String title = generateRandomTitle();
-    String author = generateRandomAuthor();
+    String firstName = getRandomFirstName();
+    String lastName = generateRandomLastName();
+    String email = generateRandomEmail("example.com", ".");
 
-    @Test(priority = 1, dependsOnMethods = {"testcases.wishList.TC01_Create_New_Wishlist.createNewBook_P"}, description = "update existed book with valid data")
+    @Test(priority = 1, dependsOnMethods = {"testcases.wishList.TC01_Create_New_Wishlist.createNewWishlist_P"}, description = "update existed wishlist with valid data")
 
-    public void updateExistingBook_P() {
+    public void updateExistingWishlist_P() {
         Response response = given().log().all()
                 .auth().preemptive().basic("admin","admin")
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
-                .body(getCreateBookBody(title, author, isbn, releaseDate))
+                .body(getCreateWishlistBody(firstName, lastName, email))
                 .when().put(WISHLISTS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
@@ -51,29 +50,23 @@ public class TC03_Update_Existing_Wishlist extends TestBase {
         Assert.assertTrue(bookID > 0, "Book ID should be a positive number");
         System.out.println("✅ [TC04] Validate 'id' is a number and positive");
 
-        String actualTitle = response.jsonPath().getString("title");
-        Assert.assertNotNull(actualTitle, "Title should not be null");
-        Assert.assertFalse(actualTitle.isEmpty(), "Title should not be empty");
-        Assert.assertEquals(actualTitle, title, "Title should match the request");
-        System.out.println("✅ [TC09] Validate 'title' is not null, not empty, and matches the input");
+        String actualFirstName = response.jsonPath().getString("firstName");
+        Assert.assertNotNull(actualFirstName, "First name should not be null");
+        Assert.assertFalse(actualFirstName.isEmpty(), "First name should not be empty");
+        Assert.assertEquals(actualFirstName, firstName, "First name should match the request");
+        System.out.println("✅ [TC09] Validate 'firstName' is not null, not empty, and matches the input");
 
-        String actualAuthor = response.jsonPath().getString("author");
-        Assert.assertNotNull(actualAuthor, "Author should not be null");
-        Assert.assertFalse(actualAuthor.isEmpty(), "Author should not be empty");
-        Assert.assertEquals(actualAuthor, author, "Author should match the request");
-        System.out.println("✅ [TC10] Validate 'author' is not null, not empty, and matches the input");
+        String actualLastName = response.jsonPath().getString("lastName");
+        Assert.assertNotNull(actualLastName, "Last name should not be null");
+        Assert.assertFalse(actualLastName.isEmpty(), "Last name should not be empty");
+        Assert.assertEquals(actualLastName, lastName, "Last name should match the request");
+        System.out.println("✅ [TC10] Validate 'lastName' is not null, not empty, and matches the input");
 
-        String actualIsbn = response.jsonPath().getString("isbn");
-        Assert.assertNotNull(actualIsbn, "ISBN should not be null");
-        Assert.assertFalse(actualIsbn.isEmpty(), "ISBN should not be empty");
-        Assert.assertEquals(actualIsbn, isbn, "ISBN should match the request");
-        System.out.println("✅ [TC11] Validate 'isbn' is not null, not empty, and matches the input");
-
-        String actualReleaseDate = response.jsonPath().getString("releaseDate");
-        Assert.assertNotNull(actualReleaseDate, "ReleaseDate should not be null");
-        Assert.assertFalse(actualReleaseDate.isEmpty(), "ReleaseDate should not be empty");
-        Assert.assertEquals(actualReleaseDate, releaseDate, "ReleaseDate should match the request");
-        System.out.println("✅ [TC12] Validate 'releaseDate' is not null, not empty, and matches the input");
+        String actualEmail = response.jsonPath().getString("email");
+        Assert.assertNotNull(actualEmail, "Email should not be null");
+        Assert.assertFalse(actualEmail.isEmpty(), "Email should not be empty");
+        Assert.assertEquals(actualEmail, email, "Email should match the request");
+        System.out.println("✅ [TC11] Validate 'email' is not null, not empty, and matches the input");
 
         String createdAt = response.jsonPath().getString("createdAt");
         Assert.assertNotNull(createdAt, "createdAt should not be null or empty");

--- a/src/test/java/testcases/wishList/TC05_Partial_Update_Existed_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC05_Partial_Update_Existed_Wishlist.java
@@ -10,26 +10,25 @@ import io.restassured.module.jsv.JsonSchemaValidator;
 import java.io.File;
 import static paths.Paths.WISHLIST_SCHEMA_PATH;
 import static util.Enpoint.WISHLISTS;
-import static model.CreateBookBody.getCreateBookBody;
+import static model.CreateBookBody.getCreateWishlistBody;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
 import static util.Utililty.*;
 
 public class TC05_Partial_Update_Existed_Wishlist extends TestBase {
 
-    String isbn = generateRandomIsbn();
-    String releaseDate = generateRandomPastDate();
-    String title = generateRandomTitle();
-    String author = generateRandomAuthor();
+    String firstName = getRandomFirstName();
+    String lastName = generateRandomLastName();
+    String email = generateRandomEmail("example.com", ".");
 
-    @Test(priority = 1, description = "Create new book with valid data")
+    @Test(priority = 1, description = "Partial update existing wishlist with valid data")
 
-    public void partialUpdateExistingBook_P() {
+    public void partialUpdateExistingWishlist_P() {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
                 .auth().preemptive().basic("admin","admin")
-                .body(getCreateBookBody(title, author, isbn, releaseDate))
+                .body(getCreateWishlistBody(firstName, lastName, email))
                 .when().patch(WISHLISTS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(200).assertThat()
@@ -51,29 +50,23 @@ public class TC05_Partial_Update_Existed_Wishlist extends TestBase {
         Assert.assertTrue(bookID > 0, "Book ID should be a positive number");
         System.out.println("✅ [TC04] Validate 'id' is a number and positive");
 
-        String actualTitle = response.jsonPath().getString("title");
-        Assert.assertNotNull(actualTitle, "Title should not be null");
-        Assert.assertFalse(actualTitle.isEmpty(), "Title should not be empty");
-        Assert.assertEquals(actualTitle, title, "Title should match the request");
-        System.out.println("✅ [TC09] Validate 'title' is not null, not empty, and matches the input");
+        String actualFirstName = response.jsonPath().getString("firstName");
+        Assert.assertNotNull(actualFirstName, "First name should not be null");
+        Assert.assertFalse(actualFirstName.isEmpty(), "First name should not be empty");
+        Assert.assertEquals(actualFirstName, firstName, "First name should match the request");
+        System.out.println("✅ [TC09] Validate 'firstName' is not null, not empty, and matches the input");
 
-        String actualAuthor = response.jsonPath().getString("author");
-        Assert.assertNotNull(actualAuthor, "Author should not be null");
-        Assert.assertFalse(actualAuthor.isEmpty(), "Author should not be empty");
-        Assert.assertEquals(actualAuthor, author, "Author should match the request");
-        System.out.println("✅ [TC10] Validate 'author' is not null, not empty, and matches the input");
+        String actualLastName = response.jsonPath().getString("lastName");
+        Assert.assertNotNull(actualLastName, "Last name should not be null");
+        Assert.assertFalse(actualLastName.isEmpty(), "Last name should not be empty");
+        Assert.assertEquals(actualLastName, lastName, "Last name should match the request");
+        System.out.println("✅ [TC10] Validate 'lastName' is not null, not empty, and matches the input");
 
-        String actualIsbn = response.jsonPath().getString("isbn");
-        Assert.assertNotNull(actualIsbn, "ISBN should not be null");
-        Assert.assertFalse(actualIsbn.isEmpty(), "ISBN should not be empty");
-        Assert.assertEquals(actualIsbn, isbn, "ISBN should match the request");
-        System.out.println("✅ [TC11] Validate 'isbn' is not null, not empty, and matches the input");
-
-        String actualReleaseDate = response.jsonPath().getString("releaseDate");
-        Assert.assertNotNull(actualReleaseDate, "ReleaseDate should not be null");
-        Assert.assertFalse(actualReleaseDate.isEmpty(), "ReleaseDate should not be empty");
-        Assert.assertEquals(actualReleaseDate, releaseDate, "ReleaseDate should match the request");
-        System.out.println("✅ [TC12] Validate 'releaseDate' is not null, not empty, and matches the input");
+        String actualEmail = response.jsonPath().getString("email");
+        Assert.assertNotNull(actualEmail, "Email should not be null");
+        Assert.assertFalse(actualEmail.isEmpty(), "Email should not be empty");
+        Assert.assertEquals(actualEmail, email, "Email should match the request");
+        System.out.println("✅ [TC11] Validate 'email' is not null, not empty, and matches the input");
 
         String createdAt = response.jsonPath().getString("createdAt");
         Assert.assertNotNull(createdAt, "createdAt should not be null or empty");

--- a/src/test/java/testcases/wishList/TC07_Delete_A_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC07_Delete_A_Wishlist.java
@@ -6,26 +6,20 @@ import org.testng.annotations.Test;
 import testcases.TestBase;
 
 import static io.restassured.RestAssured.given;
-import static model.CreateBookBody.getCreateBookBody;
 import static org.hamcrest.Matchers.lessThan;
 import static util.Utililty.*;
 import static util.Enpoint.WISHLISTS;
 
 public class TC07_Delete_A_Wishlist extends TestBase {
 
-    String isbn = generateRandomIsbn();
-    String releaseDate = generateRandomPastDate();
-    String title = generateRandomTitle();
-    String author = generateRandomAuthor();
 
-    @Test(priority = 1, description = "Create new book with valid data")
+    @Test(priority = 1, description = "Delete existing wishlist")
 
-    public void deleteExistedBook() {
+    public void deleteExistedWishlist() {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")
                 .auth().preemptive().basic("admin","admin")
-                .body(getCreateBookBody(title, author, isbn, releaseDate))
                 .when().delete(WISHLISTS + bookID)
                 .then().log().all()
                 .assertThat().statusCode(204).assertThat()


### PR DESCRIPTION
## Summary
- send wishlist data for create/update/patch wishlist tests
- remove request body from delete wishlist test

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671786b050832fa1b952444ae2b862