### PR TITLE
Fix method names to align with test classes

### DIFF
--- a/src/test/java/testcases/houseHolding/TC01_Create_New_Household.java
+++ b/src/test/java/testcases/houseHolding/TC01_Create_New_Household.java
@@ -25,8 +25,8 @@ public class TC01_Create_New_Household extends TestBase {
 
     String fullName = generateRandomFullName();
 
-    @Test(priority = 1, description = "Create new book with valid data")
-    public void createNewBook_P() throws JsonProcessingException {
+    @Test(priority = 1, description = "Create new household with valid data")
+    public void createNewHousehold_P() throws JsonProcessingException {
         CreateHousehold household = new CreateHousehold().setName(fullName);
 
         Map<String, String> headers = Map.of(

--- a/src/test/java/testcases/houseHolding/TC02_Get_A_Household.java
+++ b/src/test/java/testcases/houseHolding/TC02_Get_A_Household.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.lessThan;
 
 public class TC02_Get_A_Household extends TestBase {
 
-    @Test(priority = 1, description = "Check Get Books working and return response as excpected")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check Get household working and return response as expected")
+    public void checkGetHouseholdWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/houseHolding/TC03_Update_Existing_Household.java
+++ b/src/test/java/testcases/houseHolding/TC03_Update_Existing_Household.java
@@ -19,9 +19,9 @@ public class TC03_Update_Existing_Household extends TestBase {
 
     String fullName = generateRandomFullName();
 
-    @Test(priority = 1, dependsOnMethods = {"testcases.houseHolding.TC01_Create_New_Household.createNewBook_P"}, description = "update existed household with valid data")
+    @Test(priority = 1, dependsOnMethods = {"testcases.houseHolding.TC01_Create_New_Household.createNewHousehold_P"}, description = "update existed household with valid data")
 
-    public void updateExistingBook_P() {
+    public void updateExistingHousehold_P() {
         Response response = given().log().all()
                 .auth().preemptive().basic("admin","admin")
                 .header("Content-Type", "application/json")

--- a/src/test/java/testcases/houseHolding/TC04_Get_Existed_Household.java
+++ b/src/test/java/testcases/houseHolding/TC04_Get_Existed_Household.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.lessThan;
 
 public class TC04_Get_Existed_Household extends TestBase {
 
-    @Test(priority = 1, description = "Check Get Books working and return response as excpected")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check Get household working and return response as expected")
+    public void checkGetHouseholdWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/houseHolding/TC05_Partial_Update_Existed_Household.java
+++ b/src/test/java/testcases/houseHolding/TC05_Partial_Update_Existed_Household.java
@@ -21,7 +21,7 @@ public class TC05_Partial_Update_Existed_Household extends TestBase {
 
     @Test(priority = 1, description = "partial update existed household with valid data")
 
-    public void partialUpdateExistingBook_P() {
+    public void partialUpdateExistingHousehold_P() {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/houseHolding/TC06_Get_A_Household.java
+++ b/src/test/java/testcases/houseHolding/TC06_Get_A_Household.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.lessThan;
 
 public class TC06_Get_A_Household extends TestBase {
 
-    @Test(priority = 1, description = "Check Get Books working and return response as excpected")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check Get household working and return response as expected")
+    public void checkGetHouseholdWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/houseHolding/TC07_Delete_A_Household.java
+++ b/src/test/java/testcases/houseHolding/TC07_Delete_A_Household.java
@@ -13,7 +13,7 @@ public class TC07_Delete_A_Household extends TestBase {
 
     @Test(priority = 1, description = "delete existed household")
 
-    public void deleteExistedBook() {
+    public void deleteExistedHousehold() {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/houseHolding/TC08_Get_A_Household.java
+++ b/src/test/java/testcases/houseHolding/TC08_Get_A_Household.java
@@ -10,8 +10,8 @@ import static util.Enpoint.HOUSEHOLDS;
 
 public class TC08_Get_A_Household extends TestBase {
 
-    @Test(priority = 1, description = "Check that GET after DELETE returns 404 Not Found for deleted book")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check that GET after DELETE returns 404 Not Found for deleted household")
+    public void checkGetHouseholdWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/users/TC01_Create_New_User.java
+++ b/src/test/java/testcases/users/TC01_Create_New_User.java
@@ -23,7 +23,7 @@ public class TC01_Create_New_User extends TestBase {
 
     @Test(priority = 1, description = "Create new user with valid data")
 
-    public void createNewBook_P() {
+    public void createNewUser_P() {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/users/TC02_Get_A_User.java
+++ b/src/test/java/testcases/users/TC02_Get_A_User.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.lessThan;
 
 public class TC02_Get_A_User extends TestBase {
 
-    @Test(priority = 1, description = "Check Get Books working and return response as excpected")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check Get user working and return response as expected")
+    public void checkGetUserWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/users/TC03_Update_Existing_User.java
+++ b/src/test/java/testcases/users/TC03_Update_Existing_User.java
@@ -21,9 +21,9 @@ public class TC03_Update_Existing_User extends TestBase {
     String lastName = generateRandomLastName();
     String email = generateRandomEmail("example.com", "");
 
-    @Test(priority = 1, dependsOnMethods = {"testcases.users.TC01_Create_New_User.createNewBook_P"}, description = "update existed user with valid data")
+    @Test(priority = 1, dependsOnMethods = {"testcases.users.TC01_Create_New_User.createNewUser_P"}, description = "update existed user with valid data")
 
-    public void updateExistingBook_P() {
+    public void updateExistingUser_P() {
         Response response = given().log().all()
                 .auth().preemptive().basic("admin","admin")
                 .header("Content-Type", "application/json")

--- a/src/test/java/testcases/users/TC04_Get_Existed_User.java
+++ b/src/test/java/testcases/users/TC04_Get_Existed_User.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.lessThan;
 
 public class TC04_Get_Existed_User extends TestBase {
 
-    @Test(priority = 1, description = "Check Get Books working and return response as excpected")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check Get user working and return response as expected")
+    public void checkGetUserWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/users/TC05_Partial_Update_Existed_User.java
+++ b/src/test/java/testcases/users/TC05_Partial_Update_Existed_User.java
@@ -23,7 +23,7 @@ public class TC05_Partial_Update_Existed_User extends TestBase {
 
     @Test(priority = 1, description = "Partially update existed user with valid data")
 
-    public void partialUpdateExistingBook_P() {
+    public void partialUpdateExistingUser_P() {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/users/TC06_Get_A_User.java
+++ b/src/test/java/testcases/users/TC06_Get_A_User.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.lessThan;
 
 public class TC06_Get_A_User extends TestBase {
 
-    @Test(priority = 1, description = "Check Get Books working and return response as excpected")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check Get user working and return response as expected")
+    public void checkGetUserWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/users/TC07_Delete_A_User.java
+++ b/src/test/java/testcases/users/TC07_Delete_A_User.java
@@ -15,7 +15,7 @@ public class TC07_Delete_A_User extends TestBase {
 
     @Test(priority = 1, description = "Delete existed user")
 
-    public void deleteExistedBook() {
+    public void deleteExistedUser() {
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/users/TC08_Get_A_User.java
+++ b/src/test/java/testcases/users/TC08_Get_A_User.java
@@ -10,8 +10,8 @@ import static util.Enpoint.USERS;
 
 public class TC08_Get_A_User extends TestBase {
 
-    @Test(priority = 1, description = "Check that GET after DELETE returns 404 Not Found for deleted book")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check that GET after DELETE returns 404 Not Found for deleted user")
+    public void checkGetUserWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/wishList/TC02_Get_A_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC02_Get_A_Wishlist.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.lessThan;
 
 public class TC02_Get_A_Wishlist extends TestBase {
 
-    @Test(priority = 1, description = "Check Get Books working and return response as excpected")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check Get wishlist working and return response as expected")
+    public void checkGetWishlistWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/wishList/TC04_Get_Existed_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC04_Get_Existed_Wishlist.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.lessThan;
 
 public class TC04_Get_Existed_Wishlist extends TestBase {
 
-    @Test(priority = 1, description = "Check Get Books working and return response as excpected")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check Get wishlist working and return response as expected")
+    public void checkGetWishlistWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/wishList/TC06_Get_A_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC06_Get_A_Wishlist.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.lessThan;
 
 public class TC06_Get_A_Wishlist extends TestBase {
 
-    @Test(priority = 1, description = "Check Get Books working and return response as excpected")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check Get wishlist working and return response as expected")
+    public void checkGetWishlistWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")

--- a/src/test/java/testcases/wishList/TC08_Get_A_Wishlist.java
+++ b/src/test/java/testcases/wishList/TC08_Get_A_Wishlist.java
@@ -10,8 +10,8 @@ import static util.Enpoint.WISHLISTS;
 
 public class TC08_Get_A_Wishlist extends TestBase {
 
-    @Test(priority = 1, description = "Check that GET after DELETE returns 404 Not Found for deleted book")
-    public void checkGetBooksWorking_P(){
+    @Test(priority = 1, description = "Check that GET after DELETE returns 404 Not Found for deleted wishlist")
+    public void checkGetWishlistWorking_P(){
         Response response = given().log().all()
                 .header("Content-Type", "application/json")
                 .header("g-token", "ROM831ESV")


### PR DESCRIPTION
## Summary
- rename methods in wishlist, user, and household tests so method names align with their classes

## Testing
- `mvn -q -DskipTests test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68672f26a0e0832f97a7ad08c1ec343f